### PR TITLE
Refine About page snapshot layout and fonts

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -52,23 +52,23 @@ import { feedback } from "../content/feedback.js";
      */}
     <section class="px-6 md:px-12">
       <div class="mx-auto max-w-6xl">
-        <h2 class="text-2xl md:text-3xl font-bold text-center">Snapshot</h2>
-        <div class="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
+        <h2 class="font-serif text-2xl md:text-3xl font-bold text-center">Snapshot</h2>
+        <div class="mt-8 grid grid-cols-1 sm:grid-cols-2 gap-5">
           <article class="rounded-2xl border bg-white p-5 shadow-sm hover:shadow-md transition-shadow">
-            <h3 class="font-semibold">Where I’m from</h3>
-            <p class="mt-2 text-sm text-gray-700">Malaysia → Singapore. Grew up in a family console shop; studied game programming; learned to turn curiosity into structured systems.</p>
+            <h3 class="font-serif text-lg font-semibold">Where I’m from</h3>
+            <p class="mt-2 text-base md:text-lg text-gray-700">Malaysia → Singapore. Grew up in a family console shop; studied game programming; learned to turn curiosity into structured systems.</p>
           </article>
           <article class="rounded-2xl border bg-white p-5 shadow-sm hover:shadow-md transition-shadow">
-            <h3 class="font-semibold">What I do best</h3>
-            <p class="mt-2 text-sm text-gray-700">Bring clarity, align stakeholders, and ship quietly-powerful systems people rely on every day.</p>
+            <h3 class="font-serif text-lg font-semibold">What I do best</h3>
+            <p class="mt-2 text-base md:text-lg text-gray-700">Bring clarity, align stakeholders, and ship quietly-powerful systems people rely on every day.</p>
           </article>
           <article class="rounded-2xl border bg-white p-5 shadow-sm hover:shadow-md transition-shadow">
-            <h3 class="font-semibold">How I work</h3>
-            <p class="mt-2 text-sm text-gray-700">Evidence-led, people-first, adoption-focused. Balance long-term maintenance with near-term outcomes.</p>
+            <h3 class="font-serif text-lg font-semibold">How I work</h3>
+            <p class="mt-2 text-base md:text-lg text-gray-700">Evidence-led, people-first, adoption-focused. Balance long-term maintenance with near-term outcomes.</p>
           </article>
           <article class="rounded-2xl border bg-white p-5 shadow-sm hover:shadow-md transition-shadow">
-            <h3 class="font-semibold">Outside work</h3>
-            <p class="mt-2 text-sm text-gray-700">Strength training and baking experiments — applying product thinking to personal systems.</p>
+            <h3 class="font-serif text-lg font-semibold">Outside work</h3>
+            <p class="mt-2 text-base md:text-lg text-gray-700">Strength training and baking experiments — applying product thinking to personal systems.</p>
           </article>
         </div>
       </div>
@@ -79,19 +79,19 @@ import { feedback } from "../content/feedback.js";
      */}
     <section class="px-6 md:px-12 mt-14">
       <div class="mx-auto max-w-6xl">
-        <h2 class="text-2xl md:text-3xl font-bold text-center">Selected Impact</h2>
+        <h2 class="font-serif text-2xl md:text-3xl font-bold text-center">Selected Impact</h2>
         <div class="mt-8 space-y-5">
           <div class="rounded-2xl border bg-white p-6 shadow-sm hover:shadow-md transition-shadow">
-            <h3 class="font-semibold">BlueSG · Public EV Car‑Share</h3>
-            <p class="mt-2 text-gray-700 text-sm md:text-base">Kept <strong>900+ EVs</strong> and <strong>1,500+ chargers</strong> operational during a live system rebuild. Aligned nine senior leaders, unified roadmaps, and grew a new segment by ~20%.</p>
+            <h3 class="font-serif text-lg md:text-xl font-semibold">BlueSG · Public EV Car‑Share</h3>
+            <p class="mt-2 text-gray-700 text-base md:text-lg">Kept <strong>900+ EVs</strong> and <strong>1,500+ chargers</strong> operational during a live system rebuild. Aligned nine senior leaders, unified roadmaps, and grew a new segment by ~20%.</p>
           </div>
           <div class="rounded-2xl border bg-white p-6 shadow-sm hover:shadow-md transition-shadow">
-            <h3 class="font-semibold">Neuron Mobility · Safety & Onboarding</h3>
-            <p class="mt-2 text-gray-700 text-sm md:text-base">Cut KYC from days to seconds; reduced safety violations ~12% via parking guidance; launched in multiple cities on schedule.</p>
+            <h3 class="font-serif text-lg md:text-xl font-semibold">Neuron Mobility · Safety & Onboarding</h3>
+            <p class="mt-2 text-gray-700 text-base md:text-lg">Cut KYC from days to seconds; reduced safety violations ~12% via parking guidance; launched in multiple cities on schedule.</p>
           </div>
           <div class="rounded-2xl border bg-white p-6 shadow-sm hover:shadow-md transition-shadow">
-            <h3 class="font-semibold">Yara International · Smallholder Tools</h3>
-            <p class="mt-2 text-gray-700 text-sm md:text-base">Scaled adoption to <strong>3M+ farmers</strong> across 12 countries with SMS‑first onboarding; improved retention ~18%; co-built MVPs in the field.</p>
+            <h3 class="font-serif text-lg md:text-xl font-semibold">Yara International · Smallholder Tools</h3>
+            <p class="mt-2 text-gray-700 text-base md:text-lg">Scaled adoption to <strong>3M+ farmers</strong> across 12 countries with SMS‑first onboarding; improved retention ~18%; co-built MVPs in the field.</p>
           </div>
         </div>
       </div>
@@ -112,7 +112,7 @@ import { feedback } from "../content/feedback.js";
     <section class="px-6 md:px-12 mt-16 mb-24">
       <div class="mx-auto max-w-4xl text-center rounded-2xl border bg-white p-8 shadow-sm">
         <h3 class="font-serif text-2xl md:text-3xl">Want to see how I’d approach your problem?</h3>
-        <p class="mt-3 text-gray-700">I’m remote‑friendly and happy to walk through a case or sketch a quick approach.</p>
+        <p class="mt-3 text-gray-700 text-base md:text-lg">I’m remote‑friendly and happy to walk through a case or sketch a quick approach.</p>
         <div class="mt-6 flex items-center justify-center gap-4">
           <a href="/projects" class="btn">View Case Studies</a>
           <a href="mailto:sena.lim87@gmail.com" class="btn btn-outline">Email Me</a>


### PR DESCRIPTION
## Summary
- Display About page snapshot as a 2x2 grid
- Align About page typography with Home page styles

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68998f2042e8833194ada2941d9f26f4