### PR TITLE
Refine feedback carousel with navigation controls

### DIFF
--- a/src/components/FeedbackCarousel.astro
+++ b/src/components/FeedbackCarousel.astro
@@ -1,7 +1,6 @@
 ---
 // FeedbackCarousel.astro
 // Props: items: Array<{ author: string; role: string; body: string }>, title?: string
-import { feedback } from "../content/feedback.js";
 
 const { items = [], title = "What People Say" } = Astro.props;
 const id = "fb-" + Math.random().toString(36).slice(2);
@@ -21,29 +20,65 @@ const id = "fb-" + Math.random().toString(36).slice(2);
       <ul class="flex gap-6 px-6 md:px-12 py-1">
         {items.map((t, i) => (
           <li class="snap-center shrink-0 w-[88%] sm:w-[70%] md:w-[56%] lg:w-[48%] xl:w-[42%] mx-auto">
-            <figure class="relative rounded-2xl border border-gray-200 bg-white p-6 md:p-8
-               shadow-sm hover:shadow-md transition-shadow">
-                  <!-- Quote that moves with the card -->
-                  <span
-                    aria-hidden="true"
-                    class="pointer-events-none select-none absolute left-2 top-1 md:left-3 md:top-0
-                           text-miloYellow text-5xl md:text-6xl font-serif leading-none z-10">
-                    “
-                  </span>
-                                
-                  <!-- add left padding so text doesn’t collide with the quote -->
-                  <blockquote class="italic pl-4 md:pl-6 body-text text-gray-900 leading-relaxed">
-                    {t.body}
-                  </blockquote>
+            <figure class="relative rounded-2xl border border-gray-200 bg-white p-6 md:p-8 shadow-sm hover:shadow-md transition-shadow">
+              <!-- Quote that moves with the card -->
+              <span
+                aria-hidden="true"
+                class="pointer-events-none select-none absolute left-2 top-1 md:left-3 md:top-0 text-miloYellow text-5xl md:text-6xl font-serif leading-none z-10"
+              >
+                “
+              </span>
 
-                  <figcaption class="mt-4 body-text text-gray-600">
-                    <span class="font-semibold text-gray-900">{t.author}</span>
-                    <span class="text-gray-500"> · {t.role}</span>
-                  </figcaption>
-          </figure>
+              <!-- add left padding so text doesn’t collide with the quote -->
+              <blockquote class="italic pl-4 md:pl-6 body-text text-gray-900 leading-relaxed">
+                {t.body}
+              </blockquote>
+
+              <figcaption class="mt-4 body-text text-gray-600">
+                <span class="font-semibold text-gray-900">{t.author}</span>
+                <span class="text-gray-500"> · {t.role}</span>
+              </figcaption>
+            </figure>
           </li>
         ))}
       </ul>
+    </div>
+
+    <!-- Arrows -->
+    <div class="pointer-events-none absolute inset-y-0 left-0 right-0 flex items-center justify-between px-2 md:px-4">
+      <button
+        data-prev
+        aria-label="Previous slide"
+        class="pointer-events-auto p-2 rounded-full bg-white shadow text-gray-600 hover:text-gray-900"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5 md:h-6 md:w-6">
+          <polyline points="15 18 9 12 15 6" />
+        </svg>
+      </button>
+      <button
+        data-next
+        aria-label="Next slide"
+        class="pointer-events-auto p-2 rounded-full bg-white shadow text-gray-600 hover:text-gray-900"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-5 w-5 md:h-6 md:w-6">
+          <polyline points="9 18 15 12 9 6" />
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  <!-- Dots -->
+  <div class="mt-6 flex justify-center gap-2" data-dots>
+    {items.map((_, i) => (
+      <button
+        class="h-2 w-2 rounded-full bg-gray-300 aria-[current=true]:bg-gray-900"
+        aria-current="false"
+      >
+        <span class="sr-only">Go to slide {i + 1}</span>
+      </button>
+    ))}
+  </div>
+
 </section>
 
 <style is:global>
@@ -93,3 +128,4 @@ const id = "fb-" + Math.random().toString(36).slice(2);
     updateDots();
   })();
 </script>
+


### PR DESCRIPTION
## Summary
- rebuild feedback carousel markup
- add arrow buttons and dot indicators

## Testing
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_6899b30d644883318bef2a36c5c698a9