### PR TITLE
Reuse global text sizing utilities on resume page

### DIFF
--- a/src/components/cv/TimeLine.astro
+++ b/src/components/cv/TimeLine.astro
@@ -10,9 +10,9 @@ const hasDefaultSlot = Astro.slots.has("default");
   </div>
   <div class="flex-1">
     <h3 class="heading-3 mb-1">{title}</h3>
-    <span class="text-sm text-gray-600">{subtitle}</span>
+    <span class="body-text text-gray-600">{subtitle}</span>
     {hasDefaultSlot && (
-      <div class="mt-2 text-sm">
+      <div class="mt-2 body-text">
         <slot />
       </div>
     )}

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -5,15 +5,15 @@ import TimeLineElement from "../components/cv/TimeLine.astro";
 
 <BaseLayout title="Sena Lim | Resume" sideBarActiveItemID="cv">
   <div class="text-center mb-10">
-    <h1 class="text-4xl font-bold">Sena Lim</h1>
-    <p class="text-sm text-gray-600">Product Leader</p>
+    <h1 class="font-serif text-4-5xl font-bold">Sena Lim</h1>
+    <p class="body-text text-gray-600">Product Leader</p>
   </div>
 
   <div class="grid md:grid-cols-3 gap-8">
     <!-- Summary -->
     <section class="rounded-2xl border border-gray-200 bg-white p-6 shadow-md md:col-span-1">
       <h2 class="heading-2 mb-4">Summary</h2>
-      <ul class="list-disc ml-5 space-y-2 text-sm m-0">
+      <ul class="list-disc ml-5 space-y-2 body-text m-0">
         <li>15+ years in digital product leadership, including 7+ years delivering high-stakes, policy-constrained platforms across mobility, agri-tech, and national infrastructure.</li>
         <li>Hired, led, and mentored cross-functional product teams of up to 5 at BlueSG and Yara (100% retention over 2 years), covering multiple product areas.</li>
         <li>Delivered BlueSG national EV system rebuild for 900+ vehicles and 1,500 endpoints with zero downtime, safeguarding operational continuity and public trust.</li>
@@ -105,7 +105,7 @@ import TimeLineElement from "../components/cv/TimeLine.astro";
     <!-- Certifications -->
     <section class="rounded-2xl border border-gray-200 bg-white p-6 shadow-md md:col-span-1">
       <h2 class="heading-2 mb-4">Certifications</h2>
-      <ul class="list-disc ml-5 space-y-2 text-sm m-0">
+      <ul class="list-disc ml-5 space-y-2 body-text m-0">
         <li>
           <a href="https://www.scrum.org/certificates/320451" target="_blank">Professional Scrum Owner™ II (PSPO II)</a>
         </li>
@@ -118,7 +118,7 @@ import TimeLineElement from "../components/cv/TimeLine.astro";
     <!-- Skills -->
     <section class="rounded-2xl border border-gray-200 bg-white p-6 shadow-md md:col-span-1">
       <h2 class="heading-2 mb-4">Skills</h2>
-      <ul class="list-disc ml-5 space-y-2 text-sm m-0">
+      <ul class="list-disc ml-5 space-y-2 body-text m-0">
         <li>APIs & IoT</li>
         <li>Multi‑System & Live‑Ops Delivery</li>
         <li>Agile Product Delivery (JIRA, Confluence, Miro)</li>


### PR DESCRIPTION
## Summary
- align resume typography with home page by using global `text-4-5xl` and `body-text` classes
- update timeline component to share the same `body-text` sizing for subtitles and entries

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6899fecc7fb083318e8c24a14b66e002