### PR TITLE
Fix sidebar footer background width

### DIFF
--- a/src/components/SideBarFooter.astro
+++ b/src/components/SideBarFooter.astro
@@ -3,7 +3,7 @@
 >
 </div>
 
-<div class="social-icons px-4 pb-5 pt-1 flex self-center justify-center sticky bottom-0 bg-base-200">
+<div class="social-icons px-4 pb-5 pt-1 flex justify-center sticky bottom-0 bg-base-200 w-full">
    
     <a
         href="https://www.linkedin.com/in/senalim"


### PR DESCRIPTION
## Summary
- ensure sidebar footer social icon bar spans full width to avoid white gaps

## Testing
- `npm test` (fails: Missing script "test")
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_689a0f6ed00c8331b2f76bb52b11a897