### PR TITLE
Refine desktop layout for Skills section

### DIFF
--- a/src/components/SkillCard.astro
+++ b/src/components/SkillCard.astro
@@ -1,8 +1,8 @@
 ---
-const { title } = Astro.props;
+const { title, class: className = "" } = Astro.props;
 ---
 
-<div class="rounded-2xl border bg-white p-6 shadow-sm hover:shadow-md transition-shadow">
+<div class={`rounded-2xl border bg-white p-6 shadow-sm hover:shadow-md transition-shadow ${className}`}>
   <div class="flex items-center gap-3">
     <div class="text-3xl">
       <slot name="icon" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -151,8 +151,8 @@ const featured = [...caseStudiesInclusion, ...caseStudiesMission].slice(0, 3);
     <section id="skills" class="top-margin section-gap section-spacing scroll-mt-16 lg:scroll-mt-0">
       <Divider />
       <h2 class="heading-2 mb-6 text-center">Skills & Achievements</h2>
-      <div class="mt-8 grid gap-5 md:grid-cols-3">
-        <SkillCard title="Years of Experience">
+      <div class="mt-8 grid gap-5 md:grid-cols-2">
+        <SkillCard class="md:col-span-2" title="Years of Experience">
           <span slot="icon">💼</span>
           <ul class="list-disc mt-2 pl-6 space-y-2">
             <li>15 years across B2C, B2B, B2G, and B2B2C platforms.</li>
@@ -185,7 +185,7 @@ const featured = [...caseStudiesInclusion, ...caseStudiesMission].slice(0, 3);
             Scaled adoption to <Highlight text="3M+"/> users across <Highlight text="12"/> countries at Yara through inclusive, trust‑first UX for low‑digital‑confidence users, driving measurable confidence and retention gains.
           </p>
         </SkillCard>
-        <SkillCard title="Technical Skills">
+        <SkillCard class="md:col-span-2" title="Technical Skills">
           <span slot="icon">🛠️</span>
           <ul class="list-disc mt-2 pl-6 space-y-2">
             <li>Strong technical aptitude in APIs, IoT, SaaS, and basic web & infra principles.</li>


### PR DESCRIPTION
## Summary
- Allow SkillCard to accept custom classes for layout control
- Reorder Skills & Achievements grid: Years of Experience on top, Technical Skills on bottom, others in 2x2 middle

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3fcbcc2408331bbba6c660f20b0c0