### PR TITLE
Anchor Langflow chat widget to bottom-right

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,31 +40,38 @@ const featured = [...caseStudiesInclusion, ...caseStudiesMission].slice(0, 3);
     const chat = document.querySelector("langflow-chat");
     if (!chat) return;
 
-    const getTriggerWidth = () => {
-      const btn = chat.shadowRoot?.querySelector("button");
-      return btn?.offsetWidth || 48;
-    };
+    const setup = () => {
+      const root = chat.shadowRoot;
+      if (!root) return;
 
-    const placeDialog = () => {
-      const dialog = document.body.querySelector("div[role='dialog']");
-      if (!dialog) return;
-      const width = getTriggerWidth();
-      dialog.style.setProperty("position", "fixed", "important");
-      dialog.style.setProperty("bottom", "1rem", "important");
-      dialog.style.setProperty("right", `calc(1rem + ${width}px)`, "important");
-      dialog.style.setProperty("left", "auto", "important");
-      dialog.style.setProperty("top", "auto", "important");
-      dialog.style.setProperty("transform", "none", "important");
-      dialog.style.setProperty("z-index", "50", "important");
-    };
+      const getTriggerWidth = () => {
+        const btn = root.querySelector("button");
+        return btn?.offsetWidth || 48;
+      };
 
-    const observer = new MutationObserver(placeDialog);
-    observer.observe(document.body, { childList: true, subtree: true });
+      const placeDialog = () => {
+        const dialog = root.querySelector("div[role='dialog']");
+        if (!dialog) return;
+        const width = getTriggerWidth();
+        dialog.style.setProperty("position", "fixed", "important");
+        dialog.style.setProperty("bottom", "1rem", "important");
+        dialog.style.setProperty("right", `calc(1rem + ${width}px)`, "important");
+        dialog.style.setProperty("left", "auto", "important");
+        dialog.style.setProperty("top", "auto", "important");
+        dialog.style.setProperty("transform", "none", "important");
+        dialog.style.setProperty("z-index", "50", "important");
+      };
+
+      const observer = new MutationObserver(placeDialog);
+      observer.observe(root, { childList: true, subtree: true });
+
+      placeDialog();
+    };
 
     if (customElements.get("langflow-chat")) {
-      placeDialog();
+      setup();
     } else {
-      customElements.whenDefined("langflow-chat").then(placeDialog);
+      customElements.whenDefined("langflow-chat").then(setup);
     }
   });
 </script>


### PR DESCRIPTION
## Summary
- Fix chat widget position by anchoring `langflow-chat` to bottom-right
- Align chat dialog with trigger and open it to the left of the icon

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba44ee97a88331b8c470f45cc3e8bf