### PR TITLE
Add AI Automation section with project pages

### DIFF
--- a/public/ai-automation/calendar-whatsapp.svg
+++ b/public/ai-automation/calendar-whatsapp.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400">
+  <rect width="100%" height="100%" fill="#f0f0f0" />
+  <text x="50%" y="50%" font-size="24" text-anchor="middle" fill="#333" dominant-baseline="middle">Calendar WhatsApp Alerts</text>
+</svg>

--- a/public/ai-automation/rag-assistant.svg
+++ b/public/ai-automation/rag-assistant.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400">
+  <rect width="100%" height="100%" fill="#f0f0f0" />
+  <text x="50%" y="50%" font-size="24" text-anchor="middle" fill="#333" dominant-baseline="middle">RAG Chat Assistant</text>
+</svg>

--- a/public/ai-automation/slack-data-bot.svg
+++ b/public/ai-automation/slack-data-bot.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400">
+  <rect width="100%" height="100%" fill="#f0f0f0" />
+  <text x="50%" y="50%" font-size="24" text-anchor="middle" fill="#333" dominant-baseline="middle">Slack Data Bot</text>
+</svg>

--- a/public/ai-automation/substack-digest.svg
+++ b/public/ai-automation/substack-digest.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400">
+  <rect width="100%" height="100%" fill="#f0f0f0" />
+  <text x="50%" y="50%" font-size="24" text-anchor="middle" fill="#333" dominant-baseline="middle">Substack Digest Automation</text>
+</svg>

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -1,12 +1,17 @@
 ---
 const { title, img, desc, url, badge, tags, target = "_blank" } = Astro.props;
 import { Image } from "astro:assets";
+const isSvg = typeof img === "string" && img.endsWith(".svg");
 ---
 
 <div class="md:w-1/3 w-full">
   <a href={url} target={target}>
     <div class="card bg-base-100 transition ease-in-out hover:shadow-xl mx-6 my-2 hover:scale-[102%]">
-      <Image width={750} height={422} format="webp" src={img} alt={title} />
+      {isSvg ? (
+        <img width="750" height="422" src={img} alt={title} />
+      ) : (
+        <Image width={750} height={422} format="webp" src={img} alt={title} />
+      )}
       <div class="card-body">
         <h2 class="card-title">
           {title}

--- a/src/content/automation.ts
+++ b/src/content/automation.ts
@@ -1,0 +1,34 @@
+export type AutomationProject = {
+  title: string;
+  img: string;
+  desc: string;
+  url: string;
+  badge?: string;
+};
+
+export const automationProjects: AutomationProject[] = [
+  {
+    title: "📧 Substack Digest Automation",
+    img: "/ai-automation/substack-digest.svg",
+    desc: "Daily n8n flow that summarizes Substack newsletters from Gmail, rates them and sends me a digest while marking emails as read.",
+    url: "/AI_Automation/substack-digest",
+  },
+  {
+    title: "💬 Slack Data Bot",
+    img: "/ai-automation/slack-data-bot.svg",
+    desc: "Interact with spreadsheets and databases directly from Slack using n8n.",
+    url: "/AI_Automation/slack-data-bot",
+  },
+  {
+    title: "📆 Calendar WhatsApp Alerts",
+    img: "/ai-automation/calendar-whatsapp.svg",
+    desc: "n8n watches my Google Calendar and sends WhatsApp updates when events are created, updated or deleted.",
+    url: "/AI_Automation/calendar-whatsapp",
+  },
+  {
+    title: "🧠 RAG Chat Assistant",
+    img: "/ai-automation/rag-assistant.svg",
+    desc: "Langflow-powered assistant that answers questions about me on this portfolio site.",
+    url: "/AI_Automation/rag-assistant",
+  },
+];

--- a/src/pages/AI_Automation/calendar-whatsapp.astro
+++ b/src/pages/AI_Automation/calendar-whatsapp.astro
@@ -1,0 +1,14 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+const title = "Calendar WhatsApp Alerts";
+---
+<BaseLayout title={title} sideBarActiveItemID="projects">
+  <section class="prose mx-auto">
+    <h2 class="heading-2 mb-6 text-center">{title}</h2>
+    <p>
+      This workflow keeps everyone informed when my schedule changes. Creating, updating, or deleting a Google
+      Calendar event triggers n8n to send a WhatsApp message to the right people with the latest details.
+    </p>
+    <img src="/ai-automation/calendar-whatsapp.svg" alt="Calendar to WhatsApp automation" class="mx-auto my-4" />
+  </section>
+</BaseLayout>

--- a/src/pages/AI_Automation/rag-assistant.astro
+++ b/src/pages/AI_Automation/rag-assistant.astro
@@ -1,0 +1,14 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+const title = "RAG Chat Assistant";
+---
+<BaseLayout title={title} sideBarActiveItemID="projects">
+  <section class="prose mx-auto">
+    <h2 class="heading-2 mb-6 text-center">{title}</h2>
+    <p>
+      Built with Langflow, this retrieval-augmented generation chatbot acts as my virtual assistant on the portfolio.
+      Visitors can ask it anything about my work or background and get instant answers sourced from my own content.
+    </p>
+    <img src="/ai-automation/rag-assistant.svg" alt="RAG chat assistant" class="mx-auto my-4" />
+  </section>
+</BaseLayout>

--- a/src/pages/AI_Automation/slack-data-bot.astro
+++ b/src/pages/AI_Automation/slack-data-bot.astro
@@ -1,0 +1,14 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+const title = "Slack Data Bot";
+---
+<BaseLayout title={title} sideBarActiveItemID="projects">
+  <section class="prose mx-auto">
+    <h2 class="heading-2 mb-6 text-center">{title}</h2>
+    <p>
+      Using n8n and Slack, this automation lets me query and update spreadsheet or database records directly from a
+      Slack channel. It connects through an MCP server so I can chat with data, keeping everything in context.
+    </p>
+    <img src="/ai-automation/slack-data-bot.svg" alt="Slack data bot workflow" class="mx-auto my-4" />
+  </section>
+</BaseLayout>

--- a/src/pages/AI_Automation/substack-digest.astro
+++ b/src/pages/AI_Automation/substack-digest.astro
@@ -1,0 +1,15 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+const title = "Substack Digest Automation";
+---
+<BaseLayout title={title} sideBarActiveItemID="projects">
+  <section class="prose mx-auto">
+    <h2 class="heading-2 mb-6 text-center">{title}</h2>
+    <p>
+      This n8n workflow pulls new Substack emails from my Gmail inbox each day, summarizes their content and rates each
+      newsletter based on what I can learn as a product manager. It then emails me a digest and marks the originals as
+      read so my inbox stays clean.
+    </p>
+    <img src="/ai-automation/substack-digest.svg" alt="Substack digest automation" class="mx-auto my-4" />
+  </section>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,8 @@ import { feedback } from "../content/feedback.js";
 import { caseStudiesInclusion, caseStudiesMission } from "../content/casestudies";
 import AboutCard from "../components/AboutCard.astro";
 import SkillCard from "../components/SkillCard.astro";
+import Card from "../components/Card.astro";
+import { automationProjects } from "../content/automation";
 
 // all in one rail (or pass just one category)
 const featured = [...caseStudiesInclusion, ...caseStudiesMission].slice(0, 3);
@@ -240,7 +242,21 @@ const featured = [...caseStudiesInclusion, ...caseStudiesMission].slice(0, 3);
 </section>
 
 
-<!----------------------------------------- 
+<!-----------------------------------------
+  AI AUTOMATION
+------------------------------------------->
+<section id="ai-automation" class="top-margin section-gap section-spacing scroll-mt-16 lg:scroll-mt-0">
+<Divider />
+  <h2 class="heading-2 mb-6 text-center">AI Automation</h2>
+  <div class="mt-8 grid md:grid-cols-2 gap-5">
+    {automationProjects.map((item) => (
+      <Card {...item} target="_self" />
+    ))}
+  </div>
+</section>
+
+
+<!-----------------------------------------
   CASE STUDIES
 ------------------------------------------->
 <section id="case-studies" class="top-margin section-gap section-spacing scroll-mt-16 lg:scroll-mt-0">


### PR DESCRIPTION
## Summary
- showcase AI Automation projects with new home page section
- add four project detail pages with placeholder screenshots
- update Card component to render SVG images

## Testing
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba7d1e520083319f093af28501d686