### PR TITLE
Limit AI project preview and add listing page

### DIFF
--- a/src/pages/AI_Projects/index.astro
+++ b/src/pages/AI_Projects/index.astro
@@ -1,0 +1,17 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import HorizontalCard from "../../components/HorizontalCard.astro";
+import { aiProjects } from "../../content/ai-projects";
+---
+
+<BaseLayout title="AI Projects | Sena Lim" sideBarActiveItemID="ai-projects">
+  <section class="flex flex-col flex-1">
+    <h2 class="heading-2 text-center mb-6">AI Projects</h2>
+    {aiProjects.map((item, i) => (
+      <>
+        <HorizontalCard {...item} />
+        {i < aiProjects.length - 1 && <div class="divider my-0"></div>}
+      </>
+    ))}
+  </section>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,6 +12,7 @@ import SkillCard from "../components/SkillCard.astro";
 
 // all in one rail (or pass just one category)
 const featured = [...caseStudiesInclusion, ...caseStudiesMission].slice(0, 3);
+const aiProjectsPreview = aiProjects.slice(0, 3);
 ---
 
 <!-----------------------------------------
@@ -250,13 +251,18 @@ const featured = [...caseStudiesInclusion, ...caseStudiesMission].slice(0, 3);
     AI Projects
   </h2>
 
-    {aiProjects.map((item, i) => (
+    {aiProjectsPreview.map((item, i) => (
       <div>
         <HorizontalCard {...item} />
-        {i < aiProjects.length - 1 && <div class="divider my-0"></div>}
+        {i < aiProjectsPreview.length - 1 && <div class="divider my-0"></div>}
       </div>
     ))}
 
+    <div class="flex justify-center">
+      <a class="btn" href="/AI_Projects" target="_blank">
+        View All AI Projects
+      </a>
+    </div>
 </section>
 
 


### PR DESCRIPTION
## Summary
- Show only three AI projects on the homepage and add a link to the complete list
- Create an AI Projects index page displaying all projects with HorizontalCard layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bab40cf79083319300c4f8a3b0dd6a