### PR TITLE
Improve visuals on AI projects and case studies pages

### DIFF
--- a/src/pages/AI_Projects/index.astro
+++ b/src/pages/AI_Projects/index.astro
@@ -7,8 +7,9 @@ import { aiProjects } from "../../content/ai-projects";
 <BaseLayout title="AI Projects | Sena Lim" sideBarActiveItemID="ai-projects">
   <section class="flex flex-col flex-1">
     <h2 class="heading-2 text-center mb-6">AI Projects</h2>
-
-<p>
+    <div class="card bg-base-200 shadow-md mb-10">
+      <div class="card-body prose max-w-none text-center">
+        <p>
 This site started from a free GitHub template, but I rebuilt and customized much of it myself. When I got stuck, I turned to ChatGPT Codex to help troubleshoot and learn.<br/><br/>
 
 These AI projects came from the same mindset:<br/>
@@ -18,7 +19,9 @@ Each tool here came from a question I kept running into as a PM:<br/>
 <b>“What am I doing repeatedly that doesn’t spark joy — or impact?”</b><br/><br/>
 
 The result: four lean, purposeful systems that quietly make my work faster, clearer, and more human.<br/><br/>
-</p>
+        </p>
+      </div>
+    </div>
 
     {aiProjects.map((item, i) => (
       <>

--- a/src/pages/AI_Projects/project-calendar-whatsapp.astro
+++ b/src/pages/AI_Projects/project-calendar-whatsapp.astro
@@ -3,10 +3,12 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 const title = "Calendar to WhatsApp Alerts";
 ---
 <BaseLayout title={title} sideBarActiveItemID="ai-projects">
-  <section class="flex flex-col flex-1 prose max-w-none">
+  <section class="flex flex-col flex-1 items-center">
     <h2 class="heading-2 mb-6 text-center">{title}</h2>
-    <p>
-      <b>A canceled meeting should not require detective work.</b><br/><br/>
+    <div class="card bg-base-200 shadow-md w-full max-w-3xl">
+      <div class="card-body prose max-w-none">
+        <p>
+          <b>A canceled meeting should not require detective work.</b><br/><br/>
 
 Small shifts in calendar invites often don’t get noticed, especially in async teams. I wanted stakeholders to stay in the loop without having to check their calendars obsessively.<br/><br/>
 
@@ -15,15 +17,17 @@ Small shifts in calendar invites often don’t get noticed, especially in async 
 To bridge the gap between real-time calendar changes and team awareness through a lightweight, mobile-first alert channel.<br/><br/>
 
 <b>🧠 What it does</b><br/>
-	•	Detects new/updated/canceled calendar events<br/>
-	•	Formats a message with key details<br/>
-	•	Sends a WhatsApp alert automatically<br/>
-	•	Verifies delivery<br/><br/>
+        •       Detects new/updated/canceled calendar events<br/>
+        •       Formats a message with key details<br/>
+        •       Sends a WhatsApp alert automatically<br/>
+        •       Verifies delivery<br/><br/>
 
 <b>🛠️ Technical stack</b><br/>
 
 n8n · Google Calendar API · WhatsApp Business API (HTTP) · Webhooks · Multi-state logic
-    </p>
-    <img src="/Project 3 - Google Shared Calendar - WhatsApp Message.png" alt="Google Calendar triggers sending WhatsApp notifications" />
+        </p>
+        <img src="/Project 3 - Google Shared Calendar - WhatsApp Message.png" alt="Google Calendar triggers sending WhatsApp notifications" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+      </div>
+    </div>
   </section>
 </BaseLayout>

--- a/src/pages/AI_Projects/project-rag-chat.astro
+++ b/src/pages/AI_Projects/project-rag-chat.astro
@@ -3,10 +3,12 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 const title = "Portfolio RAG Chatbot";
 ---
 <BaseLayout title={title} sideBarActiveItemID="ai-projects">
-  <section class="flex flex-col flex-1 prose max-w-none">
+  <section class="flex flex-col flex-1 items-center">
     <h2 class="heading-2 mb-6 text-center">{title}</h2>
-    <p>
-      <b>What if people could explore my work by asking questions?</b><br/><br/>
+    <div class="card bg-base-200 shadow-md w-full max-w-3xl">
+      <div class="card-body prose max-w-none">
+        <p>
+          <b>What if people could explore my work by asking questions?</b><br/><br/>
 
 I wanted my portfolio to be more than just a static list of case studies. So I built a retrieval-augmented chatbot using Langflow — trained on my own documents.<br/><br/>
 
@@ -15,17 +17,19 @@ I wanted my portfolio to be more than just a static list of case studies. So I b
 To make my portfolio more explorable — showing how RAG can enable stakeholder self-service in a real-world context.<br/><br/>
 
 <b>🧠 What it does</b><br/>
-	•	Uses embeddings to chunk and store my docs<br/>
-	•	Accepts freeform questions via chat<br/>
-	•	Runs a semantic query to retrieve the right content<br/>
-	•	Generates a grounded GPT response with context<br/>
-	•	Runs directly in my Astro-based portfolio site<br/><br/>
+        •       Uses embeddings to chunk and store my docs<br/>
+        •       Accepts freeform questions via chat<br/>
+        •       Runs a semantic query to retrieve the right content<br/>
+        •       Generates a grounded GPT response with context<br/>
+        •       Runs directly in my Astro-based portfolio site<br/><br/>
 
 <b>🛠️ Technical stack</b><br/>
 
 Langflow · OpenAI API · Astro · Vector Store · RAG architecture · Prompt tuning
-    </p>
-    <img src="/Project 4 - RAG Chat.png" alt="Embedded chat assistant" />
-    <img src="/Project 4 - RAG Chat langflow.png" alt="Langflow RAG chat flow" />
+        </p>
+        <img src="/Project 4 - RAG Chat.png" alt="Embedded chat assistant" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+        <img src="/Project 4 - RAG Chat langflow.png" alt="Langflow RAG chat flow" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+      </div>
+    </div>
   </section>
 </BaseLayout>

--- a/src/pages/AI_Projects/project-slack-data.astro
+++ b/src/pages/AI_Projects/project-slack-data.astro
@@ -3,10 +3,12 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 const title = "Slack Data Agent";
 ---
 <BaseLayout title={title} sideBarActiveItemID="ai-projects">
-  <section class="flex flex-col flex-1 prose max-w-none">
+  <section class="flex flex-col flex-1 items-center">
     <h2 class="heading-2 mb-6 text-center">{title}</h2>
-    <p>
-      <b>Data requests shouldn’t require 3 tabs and 5 pings.</b><br/><br/>
+    <div class="card bg-base-200 shadow-md w-full max-w-3xl">
+      <div class="card-body prose max-w-none">
+        <p>
+          <b>Data requests shouldn’t require 3 tabs and 5 pings.</b><br/><br/>
 
 I often find myself trying to fetch status updates or edit rows in a shared sheet buried three folders deep. It’s tedious. So I turned Slack into a natural language interface for my data.<br/><br/>
 
@@ -15,18 +17,19 @@ I often find myself trying to fetch status updates or edit rows in a shared shee
 To reduce context-switching and make internal data instantly accessible, right from Slack.<br/><br/>
 
 <b>🧠 What it does</b><br/>
-	•	Interprets commands like “show progress for Initiative X”<br/>
-	•	Routes to the right spreadsheet/database<br/>
-	•	Pulls the row or updates the field<br/>
-	•	Returns results instantly in Slack<br/><br/>
+        •       Interprets commands like “show progress for Initiative X”<br/>
+        •       Routes to the right spreadsheet/database<br/>
+        •       Pulls the row or updates the field<br/>
+        •       Returns results instantly in Slack<br/><br/>
 
 <b>🛠️ Technical stack</b><br/>
 
 n8n · Slack API · OpenAI · MCP API · Prompt-based routing · Modular memory + tools
-    </p>
-
-    <img src="/Project 2 - Slack Workflow.png" alt="Slack trigger and AI agent workflow" />
-    <img src="/Project 2 - Slack Workflow - MCP.png" alt="MCP server trigger updating Google Sheets" />
-    <img src="/Project 2 - Slack Workflow - MCP - Row Lookup.png" alt="Workflow retrieving and filtering rows" />
+        </p>
+        <img src="/Project 2 - Slack Workflow.png" alt="Slack trigger and AI agent workflow" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+        <img src="/Project 2 - Slack Workflow - MCP.png" alt="MCP server trigger updating Google Sheets" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+        <img src="/Project 2 - Slack Workflow - MCP - Row Lookup.png" alt="Workflow retrieving and filtering rows" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+      </div>
+    </div>
   </section>
 </BaseLayout>

--- a/src/pages/AI_Projects/project-substack.astro
+++ b/src/pages/AI_Projects/project-substack.astro
@@ -3,9 +3,11 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 const title = "Substack Newsletter Summariser";
 ---
 <BaseLayout title={title} sideBarActiveItemID="ai-projects">
-  <section class="flex flex-col flex-1 prose max-w-none">
+  <section class="flex flex-col flex-1 items-center">
     <h2 class="heading-2 mb-6 text-center">{title}</h2>
-    <p>
+    <div class="card bg-base-200 shadow-md w-full max-w-3xl">
+      <div class="card-body prose max-w-none">
+        <p>
 <b>Too much good content. Too little time.</b><br/><br/>
 
 I used to keep tabs on ~10 Substack newsletters, all focused on product strategy, tech policy, and AI. But every week, I’d fall behind and then forget what I’d read.<br/><br/>
@@ -17,23 +19,22 @@ So I built a system.<br/><br/>
 To turn information overload into a structured daily insight loop — surfacing only what’s relevant to my work, without the inbox clutter.<br/><br/>
 
 <b>🧠 What it does</b><br/>
-	•	Pulls newsletter emails via Gmail API<br/>
-	•	Scores each based on product-relevance using prompt logic<br/>
-	•	Summarizes key insights with GPT<br/>
-	•	Sends me a daily digest<br/>
-	•	Marks the original emails as read<br/><br/>
+        •       Pulls newsletter emails via Gmail API<br/>
+        •       Scores each based on product-relevance using prompt logic<br/>
+        •       Summarizes key insights with GPT<br/>
+        •       Sends me a daily digest<br/>
+        •       Marks the original emails as read<br/><br/>
 
 <b>🛠️ Technical stack</b><br/>
 
 n8n · Gmail API · OpenAI GPT · Conditional logic · Error fallback<br/><br/>
 
 <b>N8N Flow</b>
-    </p>
-<p>
-    <img src="/Project 1 - Substack Newsletter Summariser.png" alt="n8n workflow summarising Substack newsletters" />
-
-<b>Summary Email</b>
- </p>
-    <img src="/Project 1 - Substack Newsletter Summariser - Email.png" alt="Summary email sample" />
+        </p>
+        <img src="/Project 1 - Substack Newsletter Summariser.png" alt="n8n workflow summarising Substack newsletters" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+        <p class="mt-6 font-bold">Summary Email</p>
+        <img src="/Project 1 - Substack Newsletter Summariser - Email.png" alt="Summary email sample" class="rounded-lg shadow-md w-full mx-auto mt-2 md:max-w-xl" />
+      </div>
+    </div>
   </section>
 </BaseLayout>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -7,7 +7,9 @@ import { caseStudiesInclusion, caseStudiesMission } from "../content/casestudies
 
 <BaseLayout title = "Case Studies | Sena Lim" sideBarActiveItemID="projects">
 <h2 class="heading-2 text-center mb-6">Case Studies</h2>
-<p>
+<div class="card bg-base-200 shadow-md mb-10">
+  <div class="card-body prose max-w-none text-center">
+    <p>
 <b>Real-world frictions. Thoughtful systems. Product thinking in action.</b><br/><br/>
 
 These aren’t past projects. They’re <b>problem spaces</b> I care deeply about.<br/><br/>
@@ -15,7 +17,9 @@ Each case explores a challenge I’ve observed in the real world, from digital e
 
 This is where I apply structured thinking to themes that matter to me:<br/>
 inclusion, dignity, trust, and systems that quietly support people.<br/><br/>
-</p>
+    </p>
+  </div>
+</div>
 
 <!-- Inclusion & Everyday Systems -->
   <div id="inclusion">


### PR DESCRIPTION
## Summary
- add highlighted intro sections to AI Projects and Case Studies landing pages
- give each AI project a card layout and responsive images for better readability

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68babbf6aff08331ad64823c4bf2bcc2