### PR TITLE
Align AI and Case Studies typography

### DIFF
--- a/src/pages/AI_Projects/index.astro
+++ b/src/pages/AI_Projects/index.astro
@@ -8,8 +8,8 @@ import { aiProjects } from "../../content/ai-projects";
   <section class="flex flex-col flex-1">
     <h2 class="heading-2 text-center mb-6">AI Projects</h2>
     <div class="card bg-base-200 shadow-md mb-10">
-      <div class="card-body prose max-w-none text-center">
-        <p>
+      <div class="card-body text-center">
+        <p class="body-text">
 This site started from a free GitHub template, but I rebuilt and customized much of it myself. When I got stuck, I turned to ChatGPT Codex to help troubleshoot and learn.<br/><br/>
 
 These AI projects came from the same mindset:<br/>

--- a/src/pages/AI_Projects/project-calendar-whatsapp.astro
+++ b/src/pages/AI_Projects/project-calendar-whatsapp.astro
@@ -5,10 +5,10 @@ const title = "Calendar to WhatsApp Alerts";
 <BaseLayout title={title} sideBarActiveItemID="ai-projects">
   <section class="flex flex-col flex-1 items-center">
     <h2 class="heading-2 mb-6 text-center">{title}</h2>
-    <div class="card bg-base-200 shadow-md w-full max-w-3xl">
-      <div class="card-body prose max-w-none">
-        <p>
-          <b>A canceled meeting should not require detective work.</b><br/><br/>
+      <div class="card bg-base-200 shadow-md w-full max-w-3xl">
+        <div class="card-body">
+          <p class="body-text">
+            <b>A canceled meeting should not require detective work.</b><br/><br/>
 
 Small shifts in calendar invites often don’t get noticed, especially in async teams. I wanted stakeholders to stay in the loop without having to check their calendars obsessively.<br/><br/>
 
@@ -22,12 +22,12 @@ To bridge the gap between real-time calendar changes and team awareness through 
         •       Sends a WhatsApp alert automatically<br/>
         •       Verifies delivery<br/><br/>
 
-<b>🛠️ Technical stack</b><br/>
+  <b>🛠️ Technical stack</b><br/>
 
-n8n · Google Calendar API · WhatsApp Business API (HTTP) · Webhooks · Multi-state logic
-        </p>
-        <img src="/Project 3 - Google Shared Calendar - WhatsApp Message.png" alt="Google Calendar triggers sending WhatsApp notifications" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+  n8n · Google Calendar API · WhatsApp Business API (HTTP) · Webhooks · Multi-state logic
+          </p>
+          <img src="/Project 3 - Google Shared Calendar - WhatsApp Message.png" alt="Google Calendar triggers sending WhatsApp notifications" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+        </div>
       </div>
-    </div>
   </section>
 </BaseLayout>

--- a/src/pages/AI_Projects/project-rag-chat.astro
+++ b/src/pages/AI_Projects/project-rag-chat.astro
@@ -5,10 +5,10 @@ const title = "Portfolio RAG Chatbot";
 <BaseLayout title={title} sideBarActiveItemID="ai-projects">
   <section class="flex flex-col flex-1 items-center">
     <h2 class="heading-2 mb-6 text-center">{title}</h2>
-    <div class="card bg-base-200 shadow-md w-full max-w-3xl">
-      <div class="card-body prose max-w-none">
-        <p>
-          <b>What if people could explore my work by asking questions?</b><br/><br/>
+      <div class="card bg-base-200 shadow-md w-full max-w-3xl">
+        <div class="card-body">
+          <p class="body-text">
+            <b>What if people could explore my work by asking questions?</b><br/><br/>
 
 I wanted my portfolio to be more than just a static list of case studies. So I built a retrieval-augmented chatbot using Langflow, trained on my own documents.<br/><br/>
 
@@ -23,13 +23,13 @@ To make my portfolio more explorable, showing how RAG can enable stakeholder sel
         •       Generates a grounded GPT response with context<br/>
         •       Runs directly in my Astro-based portfolio site<br/><br/>
 
-<b>🛠️ Technical stack</b><br/>
+  <b>🛠️ Technical stack</b><br/>
 
-Langflow · OpenAI API · Astro · Vector Store · RAG architecture · Prompt tuning
-        </p>
-        <img src="/Project 4 - RAG Chat.png" alt="Embedded chat assistant" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
-        <img src="/Project 4 - RAG Chat langflow.png" alt="Langflow RAG chat flow" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+  Langflow · OpenAI API · Astro · Vector Store · RAG architecture · Prompt tuning
+          </p>
+          <img src="/Project 4 - RAG Chat.png" alt="Embedded chat assistant" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+          <img src="/Project 4 - RAG Chat langflow.png" alt="Langflow RAG chat flow" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+        </div>
       </div>
-    </div>
   </section>
 </BaseLayout>

--- a/src/pages/AI_Projects/project-slack-data.astro
+++ b/src/pages/AI_Projects/project-slack-data.astro
@@ -5,10 +5,10 @@ const title = "Slack Data Agent";
 <BaseLayout title={title} sideBarActiveItemID="ai-projects">
   <section class="flex flex-col flex-1 items-center">
     <h2 class="heading-2 mb-6 text-center">{title}</h2>
-    <div class="card bg-base-200 shadow-md w-full max-w-3xl">
-      <div class="card-body prose max-w-none">
-        <p>
-          <b>Data requests shouldn’t require 3 tabs and 5 pings.</b><br/><br/>
+      <div class="card bg-base-200 shadow-md w-full max-w-3xl">
+        <div class="card-body">
+          <p class="body-text">
+            <b>Data requests shouldn’t require 3 tabs and 5 pings.</b><br/><br/>
 
 I often find myself trying to fetch status updates or edit rows in a shared sheet buried three folders deep. It’s tedious. So I turned Slack into a natural language interface for my data.<br/><br/>
 
@@ -22,14 +22,14 @@ To reduce context-switching and make internal data instantly accessible, right f
         •       Pulls the row or updates the field<br/>
         •       Returns results instantly in Slack<br/><br/>
 
-<b>🛠️ Technical stack</b><br/>
+  <b>🛠️ Technical stack</b><br/>
 
-n8n · Slack API · OpenAI · MCP API · Prompt-based routing · Modular memory + tools
-        </p>
-        <img src="/Project 2 - Slack Workflow.png" alt="Slack trigger and AI agent workflow" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
-        <img src="/Project 2 - Slack Workflow - MCP.png" alt="MCP server trigger updating Google Sheets" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
-        <img src="/Project 2 - Slack Workflow - MCP - Row Lookup.png" alt="Workflow retrieving and filtering rows" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+  n8n · Slack API · OpenAI · MCP API · Prompt-based routing · Modular memory + tools
+          </p>
+          <img src="/Project 2 - Slack Workflow.png" alt="Slack trigger and AI agent workflow" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+          <img src="/Project 2 - Slack Workflow - MCP.png" alt="MCP server trigger updating Google Sheets" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+          <img src="/Project 2 - Slack Workflow - MCP - Row Lookup.png" alt="Workflow retrieving and filtering rows" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+        </div>
       </div>
-    </div>
   </section>
 </BaseLayout>

--- a/src/pages/AI_Projects/project-substack.astro
+++ b/src/pages/AI_Projects/project-substack.astro
@@ -5,9 +5,9 @@ const title = "Substack Newsletter Summariser";
 <BaseLayout title={title} sideBarActiveItemID="ai-projects">
   <section class="flex flex-col flex-1 items-center">
     <h2 class="heading-2 mb-6 text-center">{title}</h2>
-    <div class="card bg-base-200 shadow-md w-full max-w-3xl">
-      <div class="card-body prose max-w-none">
-        <p>
+      <div class="card bg-base-200 shadow-md w-full max-w-3xl">
+        <div class="card-body">
+          <p class="body-text">
 <b>Too much good content. Too little time.</b><br/><br/>
 
 I used to keep tabs on ~10 Substack newsletters, all focused on product strategy, tech policy, and AI. But every week, I’d fall behind and then forget what I’d read.<br/><br/>
@@ -25,16 +25,16 @@ To turn information overload into a structured daily insight loop — surfacing 
         •       Sends me a daily digest<br/>
         •       Marks the original emails as read<br/><br/>
 
-<b>🛠️ Technical stack</b><br/>
+  <b>🛠️ Technical stack</b><br/>
 
-n8n · Gmail API · OpenAI GPT · Conditional logic · Error fallback<br/><br/>
+  n8n · Gmail API · OpenAI GPT · Conditional logic · Error fallback<br/><br/>
 
-<b>N8N Flow</b>
-        </p>
-        <img src="/Project 1 - Substack Newsletter Summariser.png" alt="n8n workflow summarising Substack newsletters" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
-        <p class="mt-6 font-bold">Summary Email</p>
-        <img src="/Project 1 - Substack Newsletter Summariser - Email.png" alt="Summary email sample" class="rounded-lg shadow-md w-full mx-auto mt-2 md:max-w-xl" />
+  <b>N8N Flow</b>
+          </p>
+          <img src="/Project 1 - Substack Newsletter Summariser.png" alt="n8n workflow summarising Substack newsletters" class="rounded-lg shadow-md w-full mx-auto mt-6 md:max-w-xl" />
+          <p class="body-text font-bold mt-6">Summary Email</p>
+          <img src="/Project 1 - Substack Newsletter Summariser - Email.png" alt="Summary email sample" class="rounded-lg shadow-md w-full mx-auto mt-2 md:max-w-xl" />
+        </div>
       </div>
-    </div>
   </section>
 </BaseLayout>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -8,8 +8,8 @@ import { caseStudiesInclusion, caseStudiesMission } from "../content/casestudies
 <BaseLayout title = "Case Studies | Sena Lim" sideBarActiveItemID="projects">
 <h2 class="heading-2 text-center mb-6">Case Studies</h2>
 <div class="card bg-base-200 shadow-md mb-10">
-  <div class="card-body prose max-w-none text-center">
-    <p>
+  <div class="card-body text-center">
+    <p class="body-text">
 <b>Real-world frictions. Thoughtful systems. Product thinking in action.</b><br/><br/>
 
 These aren’t past projects. They’re <b>problem spaces</b> I care deeply about.<br/><br/>
@@ -23,7 +23,7 @@ inclusion, dignity, trust, and systems that quietly support people.<br/><br/>
 
 <!-- Inclusion & Everyday Systems -->
   <div id="inclusion">
-    <div class="text-3xl w-full font-bold mb-5">Inclusion & Everyday Systems</div>
+    <div class="heading-3 w-full mb-5">Inclusion & Everyday Systems</div>
   </div>
   {caseStudiesInclusion.map((study, idx) => (
     <>
@@ -34,7 +34,7 @@ inclusion, dignity, trust, and systems that quietly support people.<br/><br/>
 
   <!-- Mission-Critical Strategy -->
   <div id="mission">
-    <div class="text-3xl w-full font-bold mb-5 mt-10">Mission-Critical Strategy</div>
+    <div class="heading-3 w-full mb-5 mt-10">Mission-Critical Strategy</div>
   </div>
   {caseStudiesMission.map((study, idx) => (
     <>


### PR DESCRIPTION
## Summary
- use shared `body-text` utility to make AI Projects intro responsive
- replace hardcoded text sizes in AI project detail pages with site-wide typography classes
- style Case Studies intro and section headings with `body-text`/`heading-3` for consistency

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bac72696508331b22e816aef2fb6a3