### PR TITLE
Add robot icon linking to AI Projects page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -135,6 +135,15 @@ const aiProjectsPreview = aiProjects.slice(0, 3);
           </svg>
 
         </a>
+        <a href="/AI_Projects"
+           class="inline-flex icon-size items-center justify-center leading-none text-gray-800 hover:text-textYellow"
+           aria-label="AI Projects" title="AI Projects">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon-size">
+            <rect x="7" y="7" width="10" height="8" rx="1" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 7V5a3 3 0 0 1 6 0v2m-8 8v2H6v2h12v-2h-2v-2" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M10 11h.01M14 11h.01" />
+          </svg>
+        </a>
         <a href="/cv"
            class="inline-flex icon-size items-center justify-center leading-none text-gray-800 hover:text-textYellow"
            aria-label="Resume" title="Resume">


### PR DESCRIPTION
## Summary
- add robot icon in hero section linking to AI Projects page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bac94112e88331ae0e5cb4c6c51910